### PR TITLE
Take one bucket, block its public access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Go workspace file
 go.work
 go.work.sum
+
+#IntelliJ
+.idea

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # bucket-blocker
+
+## How to run:
+
+Bucket blocker takes up to 3 flags:
+
+- **bucket**: _Required argument_.The name of the bucket to block
+
+- **profile**: _Optional argument_. The profile to use when connecting to AWS. Defaults to `default`
+
+- **region**: _Optional argument_. The region where the bucket is located. Defaults to `eu-west-1`
+
+Currently, there isn't a process to build the binary. You can run the application using the following command from the root of the repository
+
+```bash
+go run src/bucketblocker/main.go \
+-bucket <bucket_name> \
+-profile <profile_name> \
+-region <region>
+```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## How to run:
 
-Bucket blocker takes up to 3 flags:
+Bucket blocker takes 3 flags:
 
-- **bucket**: _Required argument_.The name of the bucket to block
+- **bucket**: The name of the bucket to block
 
-- **profile**: _Optional argument_. The profile to use when connecting to AWS. Defaults to `default`
+- **profile**: The profile to use when connecting to AWS.
 
-- **region**: _Optional argument_. The region where the bucket is located. Defaults to `eu-west-1`
+- **region**: The region where the bucket is located.
 
 Currently, there isn't a process to build the binary. You can run the application using the following command from the root of the repository
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/guardian/bucketblocker
+
+go 1.22.1
+
+require (
+	github.com/aws/aws-sdk-go v1.53.16
+)
+
+require (
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/aws/aws-sdk-go v1.53.16 h1:8oZjKQO/ml1WLUZw5hvF7pvYjPf8o9f57Wldoy/q9Qc=
+github.com/aws/aws-sdk-go v1.53.16/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/src/bucketblocker/main.go
+++ b/src/bucketblocker/main.go
@@ -42,6 +42,11 @@ func main() {
 	region := flag.String("region", "eu-west-1", "The region of the bucket")
 	flag.Parse()
 
+	if *name == "" {
+		fmt.Println("Please provide a bucket name")
+		return
+	}
+
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 		Profile:           *profile,

--- a/src/bucketblocker/main.go
+++ b/src/bucketblocker/main.go
@@ -11,16 +11,7 @@ import (
 )
 
 func blockPublicAccess(name string, s3Client s3.S3) {
-	publicAccessBlock, err := s3Client.GetPublicAccessBlock(&s3.GetPublicAccessBlockInput{
-		Bucket: aws.String(name),
-	})
-	if err != nil {
-		fmt.Println(err.Error())
-		return
-	}
-	fmt.Println(publicAccessBlock)
-
-	_, err = s3Client.PutPublicAccessBlock(&s3.PutPublicAccessBlockInput{
+	_, err := s3Client.PutPublicAccessBlock(&s3.PutPublicAccessBlockInput{
 		Bucket: aws.String(name),
 		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
 			BlockPublicAcls:       aws.Bool(true),
@@ -65,14 +56,14 @@ func main() {
 	s3Client := s3.New(sess)
 
 	//check bucket exists
-	bucketInfo, err := s3Client.HeadBucket(&s3.HeadBucketInput{
+	_, err := s3Client.HeadBucket(&s3.HeadBucketInput{
 		Bucket: aws.String(*name),
 	})
-	fmt.Println(bucketInfo)
 	if err != nil {
 		fmt.Println("Unable to find bucket. Please make the bucket exists and you have the correct region set.")
 		return
 	}
+	fmt.Println("Found bucket: " + *name + " in region: " + *region)
 
 	blockPublicAccess(*name, *s3Client)
 }

--- a/src/bucketblocker/main.go
+++ b/src/bucketblocker/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-func blockPublicAccess(name string, s3Client s3.S3) (*s3.PutPublicAccessBlockOutput, error) {
+func blockPublicAccess(s3Client *s3.S3, name string) (*s3.PutPublicAccessBlockOutput, error) {
 	resp, err := s3Client.PutPublicAccessBlock(&s3.PutPublicAccessBlockInput{
 		Bucket: aws.String(name),
 		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
@@ -28,7 +28,7 @@ func blockPublicAccess(name string, s3Client s3.S3) (*s3.PutPublicAccessBlockOut
 	return resp, nil
 }
 
-func validateCredentials(stsClient sts.STS, profile string) (*sts.GetCallerIdentityOutput, error) {
+func validateCredentials(stsClient *sts.STS, profile string) (*sts.GetCallerIdentityOutput, error) {
 	resp, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		return resp, errors.New("Could not find valid credentials for profile: " + profile)
@@ -51,7 +51,7 @@ func main() {
 	}))
 
 	stsClient := sts.New(sess)
-	_, err := validateCredentials(*stsClient, *profile)
+	_, err := validateCredentials(stsClient, *profile)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -69,7 +69,7 @@ func main() {
 	}
 	fmt.Println("Found bucket: " + *name + " in region: " + *region)
 
-	_, err = blockPublicAccess(*name, *s3Client)
+	_, err = blockPublicAccess(s3Client, *name)
 	if err != nil {
 		fmt.Println("Error blocking public access: " + err.Error())
 		return

--- a/src/bucketblocker/main.go
+++ b/src/bucketblocker/main.go
@@ -38,12 +38,22 @@ func validateCredentials(stsClient *sts.STS, profile string) (*sts.GetCallerIden
 
 func main() {
 	name := flag.String("bucket", "", "The name of the bucket to block")
-	profile := flag.String("profile", "default", "The name of the profile to use")
-	region := flag.String("region", "eu-west-1", "The region of the bucket")
+	profile := flag.String("profile", "", "The name of the profile to use")
+	region := flag.String("region", "", "The region of the bucket")
 	flag.Parse()
 
 	if *name == "" {
 		fmt.Println("Please provide a bucket name")
+		return
+	}
+
+	if *profile == "" {
+		fmt.Println("Please provide a profile name")
+		return
+	}
+
+	if *region == "" {
+		fmt.Println("Please provide a region")
 		return
 	}
 

--- a/src/bucketblocker/main.go
+++ b/src/bucketblocker/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+func blockPublicAccess(name string, s3Client s3.S3) {
+	//get bucket public access settings
+	publicAccessBlock, err := s3Client.GetPublicAccessBlock(&s3.GetPublicAccessBlockInput{
+		Bucket: aws.String(name),
+	})
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	fmt.Println(publicAccessBlock)
+
+	//block public access
+	_, err = s3Client.PutPublicAccessBlock(&s3.PutPublicAccessBlockInput{
+		Bucket: aws.String(name),
+		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       aws.Bool(true),
+			IgnorePublicAcls:      aws.Bool(true),
+			BlockPublicPolicy:     aws.Bool(true),
+			RestrictPublicBuckets: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	fmt.Println("Public access blocked for bucket: " + name)
+}
+
+func validateCredentials(stsClient sts.STS, profile string) {
+	//get caller identity
+	_, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		fmt.Println("Could not find valid credentials for profile: " + profile)
+		return
+	}
+	fmt.Println("Credentials validated for profile: " + profile)
+}
+
+func main() {
+	name := flag.String("bucket", "", "The name of the bucket to block")
+	profile := flag.String("profile", "default", "The name of the profile to use")
+	region := flag.String("region", "eu-west-1", "The region of the bucket")
+	flag.Parse()
+
+	//create a session using the shared credentials file, using the profile name
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Profile:           *profile,
+		Config: aws.Config{
+			Region: aws.String(*region),
+		},
+	}))
+
+	//get sts client and get caller identity
+	stsSvc := sts.New(sess)
+	validateCredentials(*stsSvc, *profile)
+
+	svc := s3.New(sess)
+
+	//check bucket exists
+	bucketInfo, err := svc.HeadBucket(&s3.HeadBucketInput{
+		Bucket: aws.String(*name),
+	})
+	fmt.Println(bucketInfo)
+	if err != nil {
+		fmt.Println(err.Error())
+		fmt.Println("Unable to find bucket. Please make the bucket exists and you have the correct region set.")
+		return
+	}
+
+	blockPublicAccess(*name, *svc)
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

An early implementation of the script. It takes in

- bucket name (required)
- AWS profile (optional)
- AWS region (optional)

and attempts to block all public access for the named bucket

Eventually, I would like this to evolve into a project that performs this operation on all buckets in an account, apart from named exceptions, but this is a good starting point.

## Why Go?

I wanted this project to be available as a small binary that developers could download directly from GitHub. Also, I wanted to experiment with Go a bit more, and this small, temporary, standalone project seemed like a good time to do it.

## How to test

Create a bucket in S3, and run this script against it.

## How can we measure success?

This project exists because we are required to comply with AWS Foundational Security Best Practices (FSBP) control S3.8, which requires that each bucket has its own policy blocking all public access. Teams will be able to run this script, and the number of buckets failing S3.8 should fall

## Have we considered potential risks?

This may block access to buckets that need to be public. Teams should try to ensure that this operation is safe, and doublecheck any downstream services

## Output

```
Credentials validated for profile: <AWS_PROFILE>
Found bucket: <BUCKET_NAME> in region: eu-west-1
Public access blocked for bucket: <BUCKET_NAME>
```