### PR TITLE
Add confirmation dialogue. Allow user to customise bucket count.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Bucket blocker takes up to 3 flags:
 
 - **dry-run**: _Optional._ Defaults to true, meaning no operation will be performed.
 
+- **max**: _Optional._ The maximum number of buckets to block. Between 1 and 100. Defaults to 100, which is the maximum number of buckets that can exist in an AWS account.
+
 Currently, there isn't a process to build the binary. You can run the application using the following command from the root of the repository
 
 ```bash
 go run main.go \
--profile <profile_name> \
--region <region>
+-profile=<profile_name> \
+-region=<region>
 ```

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	securityHubClient := securityhub.NewFromConfig(cfg)
 	s3Client := s3.NewFromConfig(cfg)
 	cfnClient := cloudformation.NewFromConfig(cfg)
-	bucketsToBlock, err := utils.FindBucketsToBlock(ctx, securityHubClient, s3Client, cfnClient)
+	bucketsToBlock, err := utils.FindBucketsToBlock(ctx, securityHubClient, s3Client, cfnClient, args.BucketCount)
 	if err != nil {
 		log.Fatalf("Error working out which buckets need blocking: %v", err)
 	}

--- a/utils/awsutils.go
+++ b/utils/awsutils.go
@@ -116,11 +116,19 @@ func FindBucketsToBlock(ctx context.Context, securityHubClient *securityhub.Clie
 
 	failingBucketCount := len(failingBuckets)
 	bucketsInStacks := listBucketsInStacks(ctx, cfnClient)
+
+	fmt.Println("\nBuckets to exclude:")
 	bucketsToBlock := Complement(failingBuckets, bucketsInStacks)
+
 	bucketsToBlockCount := len(bucketsToBlock)
 	bucketsToSkipCount := failingBucketCount - bucketsToBlockCount
 
-	fmt.Println("Found", failingBucketCount, "failing buckets, of which,", bucketsToSkipCount, "will be skipped, to avoid stack drift")
+	fmt.Println("\nBlocking the following buckets:\n")
+	for idx, bucket := range bucketsToBlock {
+		fmt.Println(idx+1, bucket)
+	}
+
+	fmt.Println("Of", failingBucketCount, "failing buckets. ", bucketsToSkipCount, "will be skipped, to avoid stack drift")
 	return bucketsToBlock, nil
 
 }

--- a/utils/awsutils.go
+++ b/utils/awsutils.go
@@ -123,7 +123,7 @@ func FindBucketsToBlock(ctx context.Context, securityHubClient *securityhub.Clie
 	bucketsToBlockCount := len(bucketsToBlock)
 	bucketsToSkipCount := failingBucketCount - bucketsToBlockCount
 
-	fmt.Println("\nBlocking the following buckets:\n")
+	fmt.Println("\nBlocking the following buckets:")
 	for idx, bucket := range bucketsToBlock {
 		fmt.Println(idx+1, bucket)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,15 +7,17 @@ import (
 )
 
 type cliArgs struct {
-	Profile string
-	Region  string
-	DryRun  bool
+	Profile     string
+	Region      string
+	DryRun      bool
+	BucketCount int32
 }
 
 func ParseArgs() cliArgs {
 	profile := flag.String("profile", "", "The name of the profile to use")
 	region := flag.String("region", "", "The region of the bucket")
 	dryRun := flag.Bool("dry-run", true, "Dry run mode")
+	bucketCount := flag.Int("max", 100, "The maximum number of buckets to attempt to process")
 	flag.Parse()
 
 	if *profile == "" {
@@ -26,10 +28,15 @@ func ParseArgs() cliArgs {
 		log.Fatal("Please provide a region")
 	}
 
+	if *bucketCount < 1 || *bucketCount > 100 {
+		log.Fatal("Please provide a max between 1 and 100")
+	}
+
 	return cliArgs{
-		Profile: *profile,
-		Region:  *region,
-		DryRun:  *dryRun,
+		Profile:     *profile,
+		Region:      *region,
+		DryRun:      *dryRun,
+		BucketCount: int32(*bucketCount),
 	}
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Allows user to specify the maximum number of buckets they would like to block, up to 100, so they can trial the tool
- Ask the user to confirm that they would like to move ahead with the changes before blocking public access
- Improved the log messages a little

## How to test

Follow the instructions in the README, experiment with the `-max` and `-dry-run` flags. Note that the format for the CLI has switched from `-flag value` to `-flag=value` (with an `=` rather than a space) as the spaced syntax is not compatible with boolean arguments. Please be careful not to hit `y` on the confirmation dialogue, as you will then start making changes to the account.

## How can we measure success?

Teams feel more confident testing out the tool on a small number of buckets. Improved user experience.
