### PR TITLE
Exclude buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Bucket blocker takes up to 3 flags:
 
 - **dry-run**: _Optional._ Defaults to true, meaning no operation will be performed.
 
+- **exclusions**: _Optional._ Comma-delimited list of buckets to exclude from blocking.
+
 - **max**: _Optional._ The maximum number of buckets to block. Between 1 and 100. Defaults to 100, which is the maximum number of buckets that can exist in an AWS account.
 
 Currently, there isn't a process to build the binary. You can run the application using the following command from the root of the repository

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	securityHubClient := securityhub.NewFromConfig(cfg)
 	s3Client := s3.NewFromConfig(cfg)
 	cfnClient := cloudformation.NewFromConfig(cfg)
-	bucketsToBlock, err := utils.FindBucketsToBlock(ctx, securityHubClient, s3Client, cfnClient, args.BucketCount)
+	bucketsToBlock, err := utils.FindBucketsToBlock(ctx, securityHubClient, s3Client, cfnClient, args.BucketCount, args.Exclusions)
 	if err != nil {
 		log.Fatalf("Error working out which buckets need blocking: %v", err)
 	}

--- a/utils/awsutils.go
+++ b/utils/awsutils.go
@@ -108,17 +108,18 @@ func listBucketsInStacks(ctx context.Context, cfnClient *cloudformation.Client) 
 	return bucketsInAStack
 }
 
-func FindBucketsToBlock(ctx context.Context, securityHubClient *securityhub.Client, s3Client *s3.Client, cfnClient *cloudformation.Client, bucketCount int32) ([]string, error) {
+func FindBucketsToBlock(ctx context.Context, securityHubClient *securityhub.Client, s3Client *s3.Client, cfnClient *cloudformation.Client, bucketCount int32, exclusions []string) ([]string, error) {
 	failingBuckets, err := findFailingBuckets(ctx, securityHubClient, bucketCount)
 	if err != nil {
 		return nil, err
 	}
 
 	failingBucketCount := len(failingBuckets)
-	bucketsInStacks := listBucketsInStacks(ctx, cfnClient)
+	excludedBuckets := listBucketsInStacks(ctx, cfnClient)
+	excludedBuckets = append(excludedBuckets, exclusions...)
 
 	fmt.Println("\nBuckets to exclude:")
-	bucketsToBlock := Complement(failingBuckets, bucketsInStacks)
+	bucketsToBlock := Complement(failingBuckets, excludedBuckets)
 
 	bucketsToBlockCount := len(bucketsToBlock)
 	bucketsToSkipCount := failingBucketCount - bucketsToBlockCount

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -46,6 +46,9 @@ func ParseArgs() cliArgs {
 }
 
 func SplitAndTrim(str string) []string {
+	if str == "" {
+		return []string{}
+	}
 	split := strings.Split(str, ",")
 	var trimmed []string
 	for _, s := range split {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"strings"
 )
 
 type cliArgs struct {
@@ -11,6 +12,7 @@ type cliArgs struct {
 	Region      string
 	DryRun      bool
 	BucketCount int32
+	Exclusions  []string
 }
 
 func ParseArgs() cliArgs {
@@ -18,6 +20,8 @@ func ParseArgs() cliArgs {
 	region := flag.String("region", "", "The region of the bucket")
 	dryRun := flag.Bool("dry-run", true, "Dry run mode")
 	bucketCount := flag.Int("max", 100, "The maximum number of buckets to attempt to process")
+	exclusions := flag.String("exclusions", "", "Comma-separated list of buckets to skip")
+
 	flag.Parse()
 
 	if *profile == "" {
@@ -37,7 +41,18 @@ func ParseArgs() cliArgs {
 		Region:      *region,
 		DryRun:      *dryRun,
 		BucketCount: int32(*bucketCount),
+		Exclusions:  SplitAndTrim(*exclusions),
 	}
+}
+
+func SplitAndTrim(str string) []string {
+	split := strings.Split(str, ",")
+	var trimmed []string
+	for _, s := range split {
+		s := strings.Trim(s, " ")
+		trimmed = append(trimmed, s)
+	}
+	return trimmed
 }
 
 func Complement[T comparable](slice []T, toRemove []T) []T {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -74,3 +74,31 @@ func TestComplementOfIdenticalSlices(t *testing.T) {
 		t.Errorf("Error computing complement of identical slices")
 	}
 }
+
+func TestStringSplit(t *testing.T) {
+	input := "a,b,c"
+	result := SplitAndTrim(input)
+	expected := []string{"a", "b", "c"}
+	evaluateResult(t, result, expected, "Error splitting string")
+}
+
+func TestStringTrim(t *testing.T) {
+	input := " a     "
+	result := SplitAndTrim(input)
+	expected := []string{"a"}
+	evaluateResult(t, result, expected, "Error trimming string")
+}
+
+func TestStringSplitAndTrim(t *testing.T) {
+	input := " a, b    , c"
+	result := SplitAndTrim(input)
+	expected := []string{"a", "b", "c"}
+	evaluateResult(t, result, expected, "Error splitting and trimming string")
+}
+
+func TestStringSplitAndTrimSpecialChars(t *testing.T) {
+	input := "--a,.@/b,c123"
+	result := SplitAndTrim(input)
+	expected := []string{"--a", ".@/b", "c123"}
+	evaluateResult(t, result, expected, "Error splitting and trimming string")
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -75,6 +75,21 @@ func TestComplementOfIdenticalSlices(t *testing.T) {
 	}
 }
 
+func TestComplementOfDuplicates(t *testing.T) {
+	slice := []string{"a", "b", "c"}
+	toRemove := []string{"c", "c"}
+	result := Complement(slice, toRemove)
+	expected := []string{"a", "b"}
+	evaluateResult(t, result, expected, "Error computing complement when slice to remove contains duplicates")
+}
+
+func TestSplittingTrimmingEmptyString(t *testing.T) {
+	input := ""
+	result := SplitAndTrim(input)
+	expected := []string{}
+	evaluateResult(t, result, expected, "Error splitting/trimming empty string")
+}
+
 func TestStringSplit(t *testing.T) {
 	input := "a,b,c"
 	result := SplitAndTrim(input)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the functionality to excude buckets from the list of buckets to block, by way of an `exclusions` flag.

## How to test

Run this branch using the instructions in the README, using the `exclusions` flag.

