### PR TITLE
ci: add build and release steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,4 +61,5 @@ jobs:
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npx semantic-release
+      # See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md  
+      run: npx -p node@v20-lts -c "npx semantic-release"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,16 @@ jobs:
 
       - name: Run tests
         run: go test ./...
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build
+        run: ./script/build.sh
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,12 @@ jobs:
         name: artifact
         path: bin
 
+    - name: Setup Node
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with: 
+        node-version: '20.14.0'
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md  
-      run: npx -p node@v20-lts -c "npx semantic-release"
+      run: npx semantic-release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,3 +40,25 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           path: bin/${{ env.BINARY_NAME }}-*
+
+  release:
+    name: Release
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Fetch build
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      with:
+        name: artifact
+        path: bin
+
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npx semantic-release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,3 +37,6 @@ jobs:
       - name: Build
         run: ./script/build.sh
 
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          path: bin/${{ env.BINARY_NAME }}-*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
   release:
     name: Release
     needs: [test, build]
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 #IntelliJ
 .idea
+
+# Go binary
+bin/

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -6,12 +6,12 @@ plugins:
 - "@semantic-release/commit-analyzer"
 - "@semantic-release/release-notes-generator"
 - "@semantic-release/github"
-  - assets:
-    - path: bin/bucketblocker-linux-amd64
-      label: linux-amd64
-    - path: bin/bucketblocker-linux-arm64
-      label: linux-arm64
-    - path: bin/bucketblocker-darwin-amd64
-      label: darwin-amd64
-    - path: bin/bucketblocker-darwin-arm64
-      label: darwin-arm64
+- assets:
+  - path: bin/bucketblocker-linux-amd64
+    label: linux-amd64
+  - path: bin/bucketblocker-linux-arm64
+    label: linux-arm64
+  - path: bin/bucketblocker-darwin-amd64
+    label: darwin-amd64
+  - path: bin/bucketblocker-darwin-arm64
+    label: darwin-arm64

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,17 @@
+branches:
+- main
+- name: beta
+  prerelease: true
+plugins:
+- "@semantic-release/commit-analyzer"
+- "@semantic-release/release-notes-generator"
+- "@semantic-release/github"
+  - assets:
+    - path: bin/bucketblocker-linux-amd64
+      label: linux-amd64
+    - path: bin/bucketblocker-linux-arm64
+      label: linux-arm64
+    - path: bin/bucketblocker-darwin-amd64
+      label: darwin-amd64
+    - path: bin/bucketblocker-darwin-arm64
+      label: darwin-arm64

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p bin
+
+# Targeting AMD (x86) Mac 
+env GOOS=darwin GOARCH=amd64 go build -o bucketblocker-darwin-amd64 main.go
+mv bucketblocker-darwin-amd64 bin/
+
+# Targeting ARM64 Mac (Apple silicon) 
+env GOOS=darwin GOARCH=arm64 go build -o bucketblocker-darwin-arm64 main.go
+mv bucketblocker-darwin-arm64 bin/


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the steps to the workflow that build the binary and release it to Github.

## How to test

See the steps run successfully below. Release should occur when this PR is merged. We can be reasonably confident that the release step now works from [this successful run](https://github.com/guardian/bucket-blocker/actions/runs/9585022551/job/26430014765)
