### PR TITLE
Package binaries into tarballs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  BINARY_NAME: bucketblocker
+  APP: bucketblocker
   GO_VERSION: 1.22.1
 
 on:
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - ms-release-tar
 
 jobs:
   test:
@@ -40,7 +40,15 @@ jobs:
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          path: bin/${{ env.BINARY_NAME }}-*
+          path: release/${{ env.APP }}-*
+
+      - name: Ouput SHA 256
+        run: |
+          echo "## Bucket Blocker release SHAs" >> $GITHUB_STEP_SUMMARY
+          echo "### ARM64" >> $GITHUB_STEP_SUMMARY 
+          echo "${{ env.SHA256_SUM_arm64 }}" >> $GITHUB_STEP_SUMMARY 
+          echo "### X86" >> $GITHUB_STEP_SUMMARY 
+          echo "${{ env.SHA256_SUM_amd64 }}" >> $GITHUB_STEP_SUMMARY
 
   release:
     name: Release
@@ -68,9 +76,9 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: artifact
-          path: bin
+          path: release
 
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+      # - name: Release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: npx semantic-release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,15 +40,7 @@ jobs:
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          path: release/${{ env.APP }}-*
-
-      - name: Ouput SHA 256
-        run: |
-          echo "## Bucket Blocker release SHAs" >> $GITHUB_STEP_SUMMARY
-          echo "### ARM64" >> $GITHUB_STEP_SUMMARY 
-          echo "${{ env.SHA256_SUM_arm64 }}" >> $GITHUB_STEP_SUMMARY 
-          echo "### X86" >> $GITHUB_STEP_SUMMARY 
-          echo "${{ env.SHA256_SUM_amd64 }}" >> $GITHUB_STEP_SUMMARY
+          path: release/**/${{ env.APP }}-*
 
   release:
     name: Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - ms-release-tar
+      - main
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,6 +28,7 @@ jobs:
         run: go test ./...
 
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -49,7 +51,7 @@ jobs:
       packages: write
       issues: write
     needs: [test, build]
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -70,7 +72,7 @@ jobs:
           name: artifact
           path: release
 
-      # - name: Release
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: npx semantic-release
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          path: release/**/${{ env.APP }}-*
+          path: release/**/${{ env.APP }}_*
 
   release:
     name: Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
       packages: write
       issues: write
     needs: [test, build]
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ go.work.sum
 #IntelliJ
 .idea
 
-# Go binary
-bin/
+# Go release packages
+release/**
+
+bucketblocker

--- a/script/build.sh
+++ b/script/build.sh
@@ -25,10 +25,11 @@ for ARCH in "${ARCHITECTURES[@]}"; do
     GOOS=darwin GOARCH=$ARCH go build -o "$APP" main.go
 
     mkdir -p "release/darwin-$ARCH"
-    pushd "release/darwin-$ARCH"
 
     TAR_NAME="${APP}_darwin-${ARCH}.tar.gz"
-    tar -czf "$TAR_NAME" "../../$APP"
+    tar -czf "release/darwin-${ARCH}/${TAR_NAME}" "$APP"
+
+    pushd "release/darwin-$ARCH"
 
     SHA256_SUM=$(shasum -a 256 "$TAR_NAME" | awk '{ print $1 }')
     echo "The following is the SHA256 sum for the '$TAR_NAME' bundle:"

--- a/script/build.sh
+++ b/script/build.sh
@@ -36,7 +36,9 @@ for ARCH in "${ARCHITECTURES[@]}"; do
 
     popd
 
-    if [ -f "$GITHUB_ENV" ]; then
-        echo "SHA256_SUM_$ARCH=$SHA256_SUM" >> "$GITHUB_ENV"
+    ## Create build summary if running in Github Actions
+    if [ -f "$GITHUB_STEP_SUMMARY" ]; then
+        echo "### Darwin ${ARCH} SHA256 sum" >> $GITHUB_STEP_SUMMARY 
+        echo "$SHA256_SUM" >> $GITHUB_STEP_SUMMARY 
     fi
 done


### PR DESCRIPTION
## What does this change?

- Makes a few changes to the build script, specifically adding a bit of boilerplate so you don't have to be in the root folder to run the script (hence the pushd and popd commands). This is fairly standard.
- More importantly, packages the release builds into tarballs instead of raw binaries.
- Prints SHA256 digests to stdout and adds them to the build summary, if run in Github Actions.

# Why?
This tool will be distributed via homebrew, which requires tarballs for distribution, as well as SHA digests for formulae.

# Tests
1. You'll still be able to run the script locally.

```
$ ./script/build.sh

=== Creating release for Darwin arm64 ===
The following is the SHA256 sum for the 'bucketblocker_darwin-arm64.tar.gz' bundle:
65da2929b1ef06e723fb5f936c8c66a309b66d3cf6f120c2b22d12d0b58aaf00

=== Creating release for Darwin amd64 ===
The following is the SHA256 sum for the 'bucketblocker_darwin-amd64.tar.gz' bundle:
15523abd7a4428e3dba9fb7d3730d17ea20f9df140e623b08a21a72b36000296
```

When the script is executed in Github actions, it will produce a summary containing the hashes which will then be used by the homebrew formulae to verify the integrity of the packages.

<img width="1303" alt="image" src="https://github.com/guardian/bucket-blocker/assets/57295823/b5e33137-fb7e-40ed-ae7c-1dbea4f7ded5">

I have also verified that the folder structure is sensible and that decompressing the tarball works.

<img width="310" alt="image" src="https://github.com/guardian/bucket-blocker/assets/57295823/1ccaa022-6561-403e-a0c0-b68e962203d5">
