### PR TITLE
Point to correct assets

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,8 +7,14 @@
       "@semantic-release/github",
       {
         "assets": [
-          { "path": "bin/bucketblocker-darwin-amd64", "label": "darwin-amd64" },
-          { "path": "bin/bucketblocker-darwin-arm64", "label": "darwin-arm64" }
+          {
+            "path": "release/darwin-amd64/bucketblocker_darwin-amd64.tar.gz",
+            "label": "darwin-amd64"
+          },
+          {
+            "path": "release/darwin-arm64/bucketblocker_darwin-arm64.tar.gz",
+            "label": "darwin-arm64"
+          }
         ]
       }
     ]


### PR DESCRIPTION
Hopefully the last PR here!

The action was not uploading any assets to the release, so I checked the logs, and lo and behold:
```
[2:27:12 PM] [semantic-release] [@semantic-release/github] › ✘  The asset bin/bucketblocker-darwin-arm64 cannot be read, and will be ignored.
[2:27:12 PM] [semantic-release] [@semantic-release/github] › ✘  The asset bin/bucketblocker-darwin-amd64 cannot be read, and will be ignored.
```

Turns out I'd forgotten to update the asset configuration file.
For now, I have manually added the tarballs to the latest release, but this fix should do this automatically going foward.
