### PR TITLE
make spelling of bucket-blocker consistent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  APP: bucketblocker
+  APP: bucket-blocker
   GO_VERSION: 1.22.1
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ go.work.sum
 # Go release packages
 release/**
 
-bucketblocker
+bucket-blocker

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,11 +8,11 @@
       {
         "assets": [
           {
-            "path": "release/darwin-amd64/bucketblocker_darwin-amd64.tar.gz",
+            "path": "release/darwin-amd64/bucket-blocker_darwin-amd64.tar.gz",
             "label": "darwin-amd64"
           },
           {
-            "path": "release/darwin-arm64/bucketblocker_darwin-arm64.tar.gz",
+            "path": "release/darwin-arm64/bucket-blocker_darwin-arm64.tar.gz",
             "label": "darwin-arm64"
           }
         ]

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ You will also need credentials for the relevant AWS account from Janus.
 
 This app runs as a binary executable on both Intel and Apple Silicon architectures. To run the binary, you can either build it from source or download it from the releases page. Apple Silicon users should download the `darwin-arm64` binary, while Intel users should download the `darwin-amd64` binary.
 
-1. **Recommended**: `wget https://github.com/guardian/bucket-blocker/releases/download/v<VERSION>/bucketblocker-<ARCHITECTURE>`
+1. **Recommended**: `wget https://github.com/guardian/bucket-blocker/releases/download/v<VERSION>/bucket-blocker-<ARCHITECTURE>`
    into a directory of your choice. You can see a list of releases
    [here](https://github.com/guardian/bucket-blocker/releases). `chmod +x` the binary.
 2. Clone the repository and build the binary using `./build.sh`
 3. Download the binary from the releases page and `chmod +x` the binary
 
 Once you have the binary, you can run it, passing in the desired flags, for example:
-`./bucketblocker-darwin-arm64 --profile deployTools --region eu-west-1`
+`./bucket-blocker-darwin-arm64 --profile deployTools --region eu-west-1`
 
 ## Local development
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/guardian/bucketblocker
+module github.com/guardian/bucket-blocker
 
 go 1.22.1
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
-	"github.com/guardian/bucketblocker/utils"
+	"github.com/guardian/bucket-blocker/utils"
 )
 
 func main() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -14,7 +14,7 @@ SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 pushd "$SCRIPT_PATH/.."
 
-APP=bucketblocker
+APP=bucket-blocker
 
 # We only build for Mac OS
 ARCHITECTURES=("arm64" "amd64")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Makes the spelling of bucket-blocker consistent across the repo.

## How to test

CI passes, binaries use the correct version (with a -)