### PR TITLE
ci: enforce the use of a dash between bucket and blocker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,16 @@ jobs:
         with:
           path: release/**/${{ env.APP }}_*
 
+  enforce-dashes:
+    name: Enforce bucket-blocker spelling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Lint naming
+        run: ./script/dash-lint.sh
+
   release:
     name: Release
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       contents: write
       packages: write
       issues: write
-    needs: [test, build]
+    needs: [test, build, enforce-dashes]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -9,7 +9,7 @@ pushd () {
 popd () {
     command popd > /dev/null
 }
-# bucketblocker
+
 SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
 pushd "$SCRIPT_PATH/.."
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -9,9 +9,8 @@ pushd () {
 popd () {
     command popd > /dev/null
 }
-
+# bucketblocker
 SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
-
 pushd "$SCRIPT_PATH/.."
 
 APP=bucket-blocker

--- a/script/dash-lint.sh
+++ b/script/dash-lint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURRENT_FILE=$(basename "${BASH_SOURCE}")
+ROOT_DIR=$(git rev-parse --show-toplevel)
+BAD_NAMES=$(grep -ril "bucketblocker" "$ROOT_DIR" --exclude "$CURRENT_FILE")
+
+
+
+if [ -n "$BAD_NAMES" ]; then
+    printf "The following files contain the incorrect string 'bucketblocker':\n\n"
+    echo "$BAD_NAMES"
+    printf "\nbucket-blocker has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling.\n"
+    exit 1;
+else
+    echo "No files contain the name 'bucketblocker'"
+    exit 0;
+fi

--- a/script/dash-lint.sh
+++ b/script/dash-lint.sh
@@ -5,9 +5,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 BAD_NAMES=$(grep -ril "bucketblocker" "$ROOT_DIR" --exclude "$CURRENT_FILE")
 
 if [ -n "$BAD_NAMES" ]; then
-    printf "The following files contain the incorrect string 'bucketblocker':\n\n"
-    echo "$BAD_NAMES"
-    printf "\nbucket-blocker has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling.\n"
+    echo "bucket-blocker has a dash in it, and inconsistencies in the codebase can cause major problems, please correct the spelling." >&2
+    printf "The following files contain the incorrect string 'bucketblocker':\n\n" >&2
+    echo "$BAD_NAMES" >&2
     exit 1;
 else
     echo "No files contain the name 'bucketblocker'"

--- a/script/dash-lint.sh
+++ b/script/dash-lint.sh
@@ -4,8 +4,6 @@ CURRENT_FILE=$(basename "${BASH_SOURCE}")
 ROOT_DIR=$(git rev-parse --show-toplevel)
 BAD_NAMES=$(grep -ril "bucketblocker" "$ROOT_DIR" --exclude "$CURRENT_FILE")
 
-
-
 if [ -n "$BAD_NAMES" ]; then
     printf "The following files contain the incorrect string 'bucketblocker':\n\n"
     echo "$BAD_NAMES"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enforces the spelling of bucket-blocker, for consistency. Previously this has cause issues such  as the brew formula being called bucket-blocker, but the program being executed using bucketblocker, which is a very odd user experience. Potentially this could be set up as a pre-commit hook, but that requires the user to (at a minimum) follow some setup instructions, which is not guaranteed to happen. A hook could also be set up using the same script as a later date.

The `-i` flag in grep indicates that matches should disregard case, so we will catch other varieties such as `BucketBlocker`, `bucketBlocker`, `BUCKETBLOCKER`, etc.

## How to test

CI should fail when it runs on a bad commit (see the action run on the first commit)

## How can we measure success?

This doesn't happen again
