### PR TITLE
docs: update readme to reflect release to brew.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,45 @@ Bucket blocker takes up to 3 flags:
 
 - **exclusions**: _Optional._ Comma-delimited list of buckets to exclude from blocking.
 
-- **max**: _Optional._ The maximum number of buckets to block. Between 1 and 100. Defaults to 100, which is the maximum number of buckets that can exist in an AWS account.
+- **max**: _Optional._ The maximum number of buckets to block. Between 1
+  and 100. Defaults to 100, which is the maximum number of buckets that can
+  exist in an AWS account.
 
 You will also need credentials for the relevant AWS account from Janus.
 
 ## Running the binary
 
-This app runs as a binary executable on both Intel and Apple Silicon architectures. To run the binary, you can either build it from source or download it from the releases page. Apple Silicon users should download the `darwin-arm64` binary, while Intel users should download the `darwin-amd64` binary.
+This application is downloadable from brew. You'll need the guardian's brew tap
+installed before you can install the application.
 
-1. **Recommended**: `wget https://github.com/guardian/bucket-blocker/releases/download/v<VERSION>/bucket-blocker-<ARCHITECTURE>`
-   into a directory of your choice. You can see a list of releases
-   [here](https://github.com/guardian/bucket-blocker/releases). `chmod +x` the binary.
-2. Clone the repository and build the binary using `./build.sh`
-3. Download the binary from the releases page and `chmod +x` the binary
+To do this all at once, run the following command:
 
-Once you have the binary, you can run it, passing in the desired flags, for example:
-`./bucket-blocker-darwin-arm64 --profile deployTools --region eu-west-1`
+```bash
+brew tap guardian/homebrew-devtools && brew install bucket-blocker
+```
+
+You can also download the binary directly from the Releases page on GitHub, or
+build it from source.
 
 ## Local development
 
 <!-- TODO enforce conventional commits via GHA-->
 
-When committing your changes, please use the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format. This will allow us to automatically generate a changelog and correctly version the application when it is released.
+When committing your changes, please use the
+[conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+format. This will allow us to automatically generate a changelog and correctly
+version the application when it is released.
 
-While developing locally, you can test the application using the following command from the root of the repository,
-without needing to build the binary:
+While developing locally, you can test the application using the following
+command from the root of the repository, without needing to build the binary:
 
 ```bash
 go run main.go -profile=<PROFILE> -region=<REGION> [OPTIONAL_FLAGS]
 ```
+
+## Releasing to brew
+
+Creating a new release of the application on brew, is currently a manual
+process. You will need to update the version, urls, and SHAs in
+[this file](https://github.com/guardian/homebrew-devtools/blob/main/Formula/bucket-blocker.rb)
+in the homebrew-devtools repo.


### PR DESCRIPTION

## What does this change?

bucket-blocker is now available on brew. Updating the README/running instructions to reflect that

## How to test

Follow the README instructions and verify that they work

## How can we measure success?

Better user experience

## Have we considered potential risks?

Keeping brew updated is a manual process. Highly likely that the repo and brew will end up out of sync. We should find a way to keep them updated in the future.
