### PR TITLE
fix: Find more buckets

### DIFF
--- a/utils/awsutils_test.go
+++ b/utils/awsutils_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cfnTypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+var exampleNonBucket = cfnTypes.StackResourceSummary{
+	LogicalResourceId:    aws.String("LogicalResourceId"),
+	PhysicalResourceId:   aws.String("PhysicalResourceId"),
+	ResourceType:         aws.String("Not::ABucket"),
+	LastUpdatedTimestamp: aws.Time(time.Now()),
+}
+
+var exampleBucket = cfnTypes.StackResourceSummary{
+	LogicalResourceId:    aws.String("LogicalResourceId"),
+	PhysicalResourceId:   aws.String("PhysicalResourceId"),
+	ResourceType:         aws.String("AWS::S3::Bucket"),
+	LastUpdatedTimestamp: aws.Time(time.Now()),
+}
+
+func FindBucketsInStacksIfTheyExist(t *testing.T) {
+	stackResources := []cfnTypes.StackResourceSummary{
+		exampleBucket, exampleNonBucket,
+	}
+	buckets := FindBucketsInStack(stackResources, "myStack")
+	if len(buckets) != 1 {
+		fmt.Println("Found buckets: ", buckets)
+		t.Errorf("Error finding buckets in stack")
+	}
+}
+
+func DoNotFindNonBucketResources(t *testing.T) {
+	stackResources := []cfnTypes.StackResourceSummary{
+		exampleNonBucket, exampleNonBucket,
+	}
+	buckets := FindBucketsInStack(stackResources, "myStack")
+	if len(buckets) != 0 {
+		fmt.Println("Found buckets: ", buckets)
+		t.Errorf("Found a bucket where there shouldn't be one")
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,12 +36,21 @@ func ParseArgs() cliArgs {
 		log.Fatal("Please provide a max between 1 and 100")
 	}
 
+	var exclusionsSlice []string
+
+	if *exclusions == "" {
+		exclusionsSlice = []string{}
+	} else {
+		fmt.Printf("Parsing exclusions")
+		exclusionsSlice = SplitAndTrim(*exclusions)
+	}
+
 	return cliArgs{
 		Profile:     *profile,
 		Region:      *region,
 		Execute:     *execute,
 		BucketCount: int32(*bucketCount),
-		Exclusions:  SplitAndTrim(*exclusions),
+		Exclusions:  exclusionsSlice,
 	}
 }
 
@@ -59,7 +68,7 @@ func Complement[T comparable](slice []T, toRemove []T) []T {
 		if !found {
 			complement = append(complement, element)
 		} else {
-			fmt.Printf("\nExcluding: %v", element)
+			fmt.Printf("\nRemoving: '%v' from slice", element)
 		}
 	}
 	fmt.Println("") //Tidy up the log output
@@ -74,5 +83,6 @@ func SplitAndTrim(str string) []string {
 		s := strings.Trim(s, " ")
 		trimmed = append(trimmed, s)
 	}
+
 	return Complement(trimmed, []string{""})
 }


### PR DESCRIPTION
## What does this change?

We are not finding all the buckets that exist in stacks. To fix/debug this, the following has been implemented:

- Paginates `ListStacks` and `ListStackResources`, so that we can gather a more complete list of buckets that should not have their access blocked
- Created `FindBucketsInStack`, a pure function that can be tested to verify its behaviour.

Separately, there's a small QOL to the parsing of the -exclusions argument that makes life (aka reading the logs) a little easier. If we are passed an empty string, it won't even attempt to `SplitAndTrim`, and will instead, immediately return an empty slice.

## How to test

Use local running instructions to verify behaviour.

## How can we measure success?

Less stack drift when the tool is applied.
